### PR TITLE
Fix for issue #19, but beware - I changed a lot of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.compiled
 *.zip
+
+# Vim
+*.un~
+.*.swp
+
+WorkbenchSandbox\

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 *.un~
 .*.swp
 
-WorkbenchSandbox\
+WorkbenchSandbox/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.compiled
 *.zip
 
+# POT
+*.po~
+
 # Vim
 *.un~
 .*.swp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,16 @@
             }
         },
         {
+            "label": "Update POT",
+            "type": "shell",
+            "command": "scripts/update-pot.sh",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
             "label": "Run nestet Gnome Shell",
             "type": "shell",
             "linux":{

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,12 +1,13 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
+    // See https://gjs.guide/extensions/development/debugging.html for how to debug Gnome extensions with Wayland
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build and Install",
+            "label": "Build",
             "type": "shell",
-            "command": "scripts/build.sh -i",
+            "command": "scripts/build.sh",
             "problemMatcher": [],
             "group": {
                 "kind": "build",
@@ -14,15 +15,21 @@
             }
         },
         {
+            "label": "Build and Install",
+            "type": "shell",
+            "command": "scripts/build.sh -i",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
             "label": "Run nestet Gnome Shell",
-            "type": "process",
-            "command": "dbus-run-session",
-            "args": [
-                "--",
-                "gnome-shell",
-                "--nested",
-                "--wayland"
-            ],
+            "type": "shell",
+            "linux":{
+                "command": "scripts/launch_gnome_nested.sh"
+            },
             "problemMatcher": [],
             "isBackground": true,
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build and Install",
+            "type": "shell",
+            "command": "scripts/build.sh -i",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Run nestet Gnome Shell",
+            "type": "process",
+            "command": "dbus-run-session",
+            "args": [
+                "--",
+                "gnome-shell",
+                "--nested",
+                "--wayland"
+            ],
+            "problemMatcher": [],
+            "isBackground": true,
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
             "problemMatcher": [],
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": false
             }
         },
         {
@@ -21,7 +21,7 @@
             "problemMatcher": [],
             "group": {
                 "kind": "build",
-                "isDefault": false
+                "isDefault": true
             }
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.4 2025-06-26
+- Changed detection algorithm. Now all batteries in /sys/class/power_supply should be detected.
+- Added support for multiple batteries in the same laptop.
+- Added setting to optionally hide the display of 0W values.
+    - Note: Spanish and Catalan translations are still missing for the new setting.
+
 ## v0.3 2024-09-22
 - Localize the power draw to the current locale.
 - Detect BAT0/BAT1/BATT folder

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 GNOME PowerTracker is a simple application that helps users monitor their power consumption on GNOME-based systems.
 
 - Does not use any dependency
-- Autodetects battery (BAT0, BAT1, BATT: /sys/class/power_supply)
-- You can configure refresh rate
+- Autodetects any battery that has a representation in /sys/class/power_supply
+- You can configure refresh rate and if 0.0W values should be hidden (to avoid screen clutter)
 
 IMPORTANT.
 - This will only work with laptops. Afaik there's no simple way to track desktop power consumption

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 16:29+0200\n"
+"POT-Creation-Date: 2025-06-26 12:03+0300\n"
 "PO-Revision-Date: 2024-09-24 16:30+0200\n"
 "Last-Translator: Marc Salat\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: extension.js:84
+#: extension.js:71
 msgid "PowerTracker"
 msgstr "PowerTracker"
 
-#: extension.js:180 prefs.js:20
+#: extension.js:239 prefs.js:20
 msgid "Preferences"
 msgstr "Preferències"
 
@@ -32,3 +32,11 @@ msgstr "General"
 #: prefs.js:25
 msgid "Refresh Rate"
 msgstr "Taxa de refresc"
+
+#: prefs.js:46
+msgid "Show 0.0W power"
+msgstr ""
+
+#: prefs.js:47
+msgid "Show a 0.0W power value instead of hiding it."
+msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 12:03+0300\n"
+"POT-Creation-Date: 2025-06-27 17:59+0300\n"
 "PO-Revision-Date: 2024-09-24 16:30+0200\n"
 "Last-Translator: Marc Salat\n"
 "Language-Team: \n"
@@ -17,11 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: extension.js:71
-msgid "PowerTracker"
-msgstr "PowerTracker"
-
-#: extension.js:239 prefs.js:20
+#: extension.js:61 prefs.js:20
 msgid "Preferences"
 msgstr "Preferències"
 
@@ -40,3 +36,6 @@ msgstr ""
 #: prefs.js:47
 msgid "Show a 0.0W power value instead of hiding it."
 msgstr ""
+
+#~ msgid "PowerTracker"
+#~ msgstr "PowerTracker"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 12:03+0300\n"
+"POT-Creation-Date: 2025-06-27 17:59+0300\n"
 "PO-Revision-Date: 2024-09-24 18:10+0200\n"
 "Last-Translator: Bernd Strobel\n"
 "Language-Team: \n"
@@ -17,11 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: extension.js:71
-msgid "PowerTracker"
-msgstr "PowerTracker"
-
-#: extension.js:239 prefs.js:20
+#: extension.js:61 prefs.js:20
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -40,3 +36,6 @@ msgstr "Zeige 0.0W Leistungswerte an"
 #: prefs.js:47
 msgid "Show a 0.0W power value instead of hiding it."
 msgstr "Zeigt einen 0.0W Wert für die Leistung an, anstatt ihn auszublenden."
+
+#~ msgid "PowerTracker"
+#~ msgstr "PowerTracker"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-26 12:03+0300\n"
 "PO-Revision-Date: 2024-09-24 18:10+0200\n"
-"Last-Translator: Uwe Senkler\n"
+"Last-Translator: Bernd Strobel\n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -35,8 +35,8 @@ msgstr "Aktualisierungsintervall"
 
 #: prefs.js:46
 msgid "Show 0.0W power"
-msgstr ""
+msgstr "Zeige 0.0W Leistungswerte an"
 
 #: prefs.js:47
 msgid "Show a 0.0W power value instead of hiding it."
-msgstr ""
+msgstr "Zeigt einen 0.0W Wert für die Leistung an, anstatt ihn auszublenden."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 16:29+0200\n"
+"POT-Creation-Date: 2025-06-26 12:03+0300\n"
 "PO-Revision-Date: 2024-09-24 18:10+0200\n"
 "Last-Translator: Uwe Senkler\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: extension.js:84
+#: extension.js:71
 msgid "PowerTracker"
 msgstr "PowerTracker"
 
-#: extension.js:180 prefs.js:20
+#: extension.js:239 prefs.js:20
 msgid "Preferences"
 msgstr "Einstellungen"
 
@@ -32,3 +32,11 @@ msgstr "Allgemein"
 #: prefs.js:25
 msgid "Refresh Rate"
 msgstr "Aktualisierungsintervall"
+
+#: prefs.js:46
+msgid "Show 0.0W power"
+msgstr ""
+
+#: prefs.js:47
+msgid "Show a 0.0W power value instead of hiding it."
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 12:03+0300\n"
+"POT-Creation-Date: 2025-06-27 17:59+0300\n"
 "PO-Revision-Date: 2024-09-24 16:42+0200\n"
 "Last-Translator: Marc Salat\n"
 "Language-Team: \n"
@@ -17,11 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: extension.js:71
-msgid "PowerTracker"
-msgstr "PowerTracker"
-
-#: extension.js:239 prefs.js:20
+#: extension.js:61 prefs.js:20
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -40,3 +36,6 @@ msgstr ""
 #: prefs.js:47
 msgid "Show a 0.0W power value instead of hiding it."
 msgstr ""
+
+#~ msgid "PowerTracker"
+#~ msgstr "PowerTracker"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 16:29+0200\n"
+"POT-Creation-Date: 2025-06-26 12:03+0300\n"
 "PO-Revision-Date: 2024-09-24 16:42+0200\n"
 "Last-Translator: Marc Salat\n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: extension.js:84
+#: extension.js:71
 msgid "PowerTracker"
 msgstr "PowerTracker"
 
-#: extension.js:180 prefs.js:20
+#: extension.js:239 prefs.js:20
 msgid "Preferences"
 msgstr "Preferencias"
 
@@ -32,3 +32,11 @@ msgstr "General"
 #: prefs.js:25
 msgid "Refresh Rate"
 msgstr "Tasa de refresco"
+
+#: prefs.js:46
+msgid "Show 0.0W power"
+msgstr ""
+
+#: prefs.js:47
+msgid "Show a 0.0W power value instead of hiding it."
+msgstr ""

--- a/po/main.pot
+++ b/po/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 12:03+0300\n"
+"POT-Creation-Date: 2025-06-27 17:59+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:71
-msgid "PowerTracker"
-msgstr ""
-
-#: extension.js:239 prefs.js:20
+#: extension.js:61 prefs.js:20
 msgid "Preferences"
 msgstr ""
 

--- a/po/main.pot
+++ b/po/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-25 15:40+0200\n"
+"POT-Creation-Date: 2025-06-26 12:03+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:84
+#: extension.js:71
 msgid "PowerTracker"
 msgstr ""
 
-#: extension.js:180 prefs.js:20
+#: extension.js:239 prefs.js:20
 msgid "Preferences"
 msgstr ""
 
@@ -31,4 +31,12 @@ msgstr ""
 
 #: prefs.js:25
 msgid "Refresh Rate"
+msgstr ""
+
+#: prefs.js:46
+msgid "Show 0.0W power"
+msgstr ""
+
+#: prefs.js:47
+msgid "Show a 0.0W power value instead of hiding it."
 msgstr ""

--- a/schemas/org.gnome.shell.extensions.powertracker.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.powertracker.gschema.xml
@@ -6,5 +6,10 @@
       <summary>Refresh rate</summary>
       <description>Refresh rate</description>
     </key>
+    <key type="b" name="showzeropower" >
+      <default>false</default>
+      <summary>Show 0.0W power</summary>
+      <description>Show a 0.0W power value instead of hiding it.</description>
+    </key>
   </schema>
 </schemalist>

--- a/scripts/launch_gnome_nested.sh
+++ b/scripts/launch_gnome_nested.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
-export G_MESSAGES_DEBUG=all
+# export G_MESSAGES_DEBUG=all
 export MUTTER_DEBUG_DUMMY_MODE_SPECS=1500x768
-export SHELL_DEBUG=all
+# export SHELL_DEBUG=all
 
 dbus-run-session -- gnome-shell --nested --wayland

--- a/scripts/launch_gnome_nested.sh
+++ b/scripts/launch_gnome_nested.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # export G_MESSAGES_DEBUG=all
-export MUTTER_DEBUG_DUMMY_MODE_SPECS=1500x768
+export MUTTER_DEBUG_DUMMY_MODE_SPECS=1300x768
 # export SHELL_DEBUG=all
 
 dbus-run-session -- gnome-shell --nested --wayland

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd /sys/class/power_supply
+while :
+do
+    for b in BAT[0-9]
+    do
+        echo "${b}: $(cat ${b}/power_now) $(cat ${b}/status)"
+    done
+    sleep 3
+done

--- a/src/extension.js
+++ b/src/extension.js
@@ -188,7 +188,7 @@ const PowerTracker = GObject.registerClass(
       }
       else if (batPowerStat.length == 1) {
         // We only have one battery, we don't need a label before the wattage.
-        if (batPowerStat[0].power > 0.0)
+        if (batPowerStat[0].power > 0.0 || this._show_zero_power)
           this._label.set_text(b.sign+String(batPowerStat[0].power));
         else
           this._label.set_text(NO_POWER_DRAW_LABEL);

--- a/src/extension.js
+++ b/src/extension.js
@@ -93,38 +93,40 @@ const PowerTracker = GObject.registerClass(
     _get_power_data() {
       var _outstring = ''
       for (var i = 0; i < 10; i++) {
-        var _bat = BAT_PATH_STUMP + i
+        const _bat = BAT_PATH_STUMP + i;
         if (GLib.file_test(_bat, GLib.FileTest.IS_DIR)) {
-          var _powernow = _bat + POWER_NOW_FILE
-          var _sign = '-'
-          var _power = 0
+          const _powernow = _bat + POWER_NOW_FILE;
+          var _sign = "";
+          var _power = 0.0;
           if (GLib.file_test(_powernow, GLib.FileTest.EXISTS)) {
             try {
               let decoder = new TextDecoder();
               var status = decoder
-                .decode(GLib.file_get_contents(_bat +  STATUS_FILE)[1])
+                .decode(GLib.file_get_contents(_bat + STATUS_FILE)[1])
                 .trim();
               if (status === "Charging") {
                 _sign = "+";
               }
-              if (status === "Full") {
-                _sign = "";
+              if (status === "Discharging") {
+                _sign = "-";
               }
-              _power = parseInt(
-                decoder.decode(GLib.file_get_contents(_powernow)[1])
-              ) / 1000000;
-              _outstring = _outstring +`${String(i)}: ${_sign}${String(_power)} W `
+              _power = (
+                parseInt(decoder.decode(GLib.file_get_contents(_powernow)[1])) /
+                1000000
+              ).toFixed(1);
+              if (_power > 0.1) {
+                if (_outstring != "") {
+                  _outstring = _outstring + ", ";
+                }
+                _outstring = _outstring + `B${String(i)} ${_sign}${String(_power)}W`;
+              }
             } catch (e) {
-              console.error("Failed to read status: " + e);
+              console.error(`Failed to read information for ${_bat}: ${e}`);
             }
           }
         }
-        else
-        {
-          break
-        }
-        this._label.set_text(_outstring);
       }
+      this._label.set_text(_outstring);
       return
     }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -95,7 +95,6 @@ const PowerTracker = GObject.registerClass(
       var outstring = ''
       for (var bat_class of BAT_CLASSES) {
         const bat = BAT_PATH_STUMP + bat_class;
-        console.warn(`Working on ${bat_class}`)
         if (GLib.file_test(bat, GLib.FileTest.IS_DIR)) {
           const powernow = bat + POWER_NOW_FILE;
           const currentnow = bat + CURRENT_NOW_FILE;
@@ -141,7 +140,7 @@ const PowerTracker = GObject.registerClass(
                 outstring + `${bat_class} ${sign}${String(power)}W`;
             }
           } catch (e) {
-            console.error(`Failed to read information for ${bat}: ${e}`);
+            console.error(`Failed to read information for ${bat_class}: ${e}`);
           }
         }
       }

--- a/src/extension.js
+++ b/src/extension.js
@@ -55,7 +55,7 @@ const PowerTracker = GObject.registerClass(
       );
 
       this._settings.connect("changed::refreshrate", (settings, key) => {
-        this._set_timeout();
+        this._set_refresh_rate();
       });
 
       // -------------

--- a/src/extension.js
+++ b/src/extension.js
@@ -45,6 +45,7 @@ const NO_BATTERY_LABEL = "No battery!";
 
 const PowerTracker = GObject.registerClass(
   class PowerTracker extends PanelMenu.Button {
+    _show_zero_power = true;
     _init(settings) {
       this._settings = settings;
 
@@ -63,7 +64,18 @@ const PowerTracker = GObject.registerClass(
         this._set_refresh_rate();
       });
 
-      this._show_zero_power = true;
+      this._settings.bind(
+        "showzeropower",
+        this,
+        "_show_zero_power",
+        Gio.SettingsBindFlags.DEFAULT
+      );
+
+      this._settings.connect('changed::showzeropower', (settings, key) => {
+        // this._show_zero_power = this._settings.get_boolean("showzeropower");
+        this._show_zero_power = settings.get_boolean(key);
+        this._get_power_data();
+      });
 
       // -------------
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,9 +31,7 @@ import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 
 // CONSTANTS
-const BAT0_PATH = "/sys/class/power_supply/BAT0";
-const BAT1_PATH = "/sys/class/power_supply/BAT1";
-const BATT_PATH = "/sys/class/power_supply/BATT";
+const BAT_PATH_STUMP = "/sys/class/power_supply/BAT";
 const POWER_NOW_FILE = "/power_now";
 const CURRENT_NOW_FILE = "/current_now";
 const VOLTAGE_NOW_FILE = "/voltage_now";
@@ -59,25 +57,6 @@ const PowerTracker = GObject.registerClass(
         this._set_timeout();
       });
 
-      // Paths
-      this.REAL_BAT_PATH = BAT0_PATH;
-      this.POWER_NOW_EXISTS = false;
-
-      // Check for BAT1 folder exists.
-      if (GLib.file_test(BAT1_PATH, GLib.FileTest.IS_DIR)) {
-        this.REAL_BAT_PATH = BAT1_PATH;
-      }
-
-      // Check for BATT folder exists.
-      if (GLib.file_test(BATT_PATH, GLib.FileTest.IS_DIR)) {
-        this.REAL_BAT_PATH = BATT_PATH;
-      }
-
-      // Check if power_now file exists.
-      this.POWER_NOW_EXISTS = GLib.file_test(
-        this.REAL_BAT_PATH + POWER_NOW_FILE,
-        GLib.FileTest.EXISTS
-      );
       // -------------
 
       this._timeout = null;
@@ -112,54 +91,41 @@ const PowerTracker = GObject.registerClass(
     }
 
     _get_power_data() {
-      var raw_power = 0;
-
-      if (this.POWER_NOW_EXISTS) {
-        raw_power = this._get_file_value(POWER_NOW_FILE);
-        raw_power = raw_power / 1000000;
-      } else {
-        var current = this._get_file_value(CURRENT_NOW_FILE);
-        var voltage = this._get_file_value(VOLTAGE_NOW_FILE);
-        raw_power = (current * voltage) / 1000000000000;
+      var _outstring = ''
+      for (var i = 0; i < 10; i++) {
+        var _bat = BAT_PATH_STUMP + i
+        if (GLib.file_test(_bat, GLib.FileTest.IS_DIR)) {
+          var _powernow = _bat + POWER_NOW_FILE
+          var _sign = '-'
+          var _power = 0
+          if (GLib.file_test(_powernow, GLib.FileTest.EXISTS)) {
+            try {
+              let decoder = new TextDecoder();
+              var status = decoder
+                .decode(GLib.file_get_contents(_bat +  STATUS_FILE)[1])
+                .trim();
+              if (status === "Charging") {
+                _sign = "+";
+              }
+              if (status === "Full") {
+                _sign = "";
+              }
+              _power = parseInt(
+                decoder.decode(GLib.file_get_contents(_powernow)[1])
+              ) / 1000000;
+              _outstring = _outstring +`${String(i)}: ${_sign}${String(_power)} W `
+            } catch (e) {
+              console.error("Failed to read status: " + e);
+            }
+          }
+        }
+        else
+        {
+          break
+        }
+        this._label.set_text(_outstring);
       }
-
-      var power = raw_power.toLocaleString(undefined, {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 1,
-      });
-      var sign = this._get_power_sign();
-      this._label.set_text(`${sign}${String(power)} W`);
-    }
-
-    _get_file_value(file) {
-      let decoder = new TextDecoder();
-      try {
-        return parseInt(
-          decoder.decode(GLib.file_get_contents(this.REAL_BAT_PATH + file)[1])
-        );
-      } catch (e) {
-        console.error("Failed to read file: " + e);
-      }
-
-      return 0;
-    }
-
-    _get_power_sign() {
-      try {
-        let decoder = new TextDecoder();
-        var status = decoder
-          .decode(GLib.file_get_contents(this.REAL_BAT_PATH + STATUS_FILE)[1])
-          .trim();
-      } catch (e) {
-        console.error("Failed to read status: " + e);
-      }
-      if (status === "Charging") {
-        return "+";
-      }
-      if (status === "Full") {
-        return "";
-      }
-      return "−";
+      return
     }
 
     destroy() {

--- a/src/extension.js
+++ b/src/extension.js
@@ -178,8 +178,8 @@ const PowerTracker = GObject.registerClass(
           );
         }
       }
-      console.log("=============================================================");
-      console.log(batPowerStat);
+      // console.log("=============================================================");
+      // console.log(batPowerStat);
       
       if (batPowerStat.length == 0) {
         this._label.set_text(NO_BATTERY_LABEL);

--- a/src/extension.js
+++ b/src/extension.js
@@ -92,8 +92,8 @@ const PowerTracker = GObject.registerClass(
     }
 
     _get_power_data() {
-      var outstring = ''
-      for (var bat_class of BAT_CLASSES) {
+      var outstr = "";
+      for (const bat_class of BAT_CLASSES) {
         const bat = BAT_PATH_STUMP + bat_class;
         if (GLib.file_test(bat, GLib.FileTest.IS_DIR)) {
           const powernow = bat + POWER_NOW_FILE;
@@ -102,11 +102,9 @@ const PowerTracker = GObject.registerClass(
           var sign = "";
           var power = 0.0;
           try {
-            let decoder = new TextDecoder();
-            var status = decoder
-              .decode(GLib.file_get_contents(bat + STATUS_FILE)[1])
-              .trim();
+            var td = new TextDecoder();
 
+            var status = td.decode(GLib.file_get_contents(bat + STATUS_FILE)[1]).trim();
             if (status === "Charging") {
               sign = "+";
             }
@@ -116,7 +114,7 @@ const PowerTracker = GObject.registerClass(
 
             if (GLib.file_test(powernow, GLib.FileTest.EXISTS)) {
               power = (
-                parseInt(decoder.decode(GLib.file_get_contents(powernow)[1])) /
+                parseInt(td.decode(GLib.file_get_contents(powernow)[1])) /
                 1000000
               ).toFixed(1);
             } else if (
@@ -124,20 +122,19 @@ const PowerTracker = GObject.registerClass(
               GLib.file_test(voltagenow, GLib.FileTest.EXISTS)
             ) {
               power = (
-                (parseInt(decoder.decode(GLib.file_get_contents(currentnow)[1])) *
-                  parseInt(decoder.decode(GLib.file_get_contents(voltagenow)[1]))) /
+                (parseInt(td.decode(GLib.file_get_contents(currentnow)[1])) *
+                  parseInt(td.decode(GLib.file_get_contents(voltagenow)[1]))) /
                 1000000000000
               ).toFixed(1);
             } else {
               throw new Error(`Couldn't find any power information endpoints!`);
             }
 
-            if (power > 0.1) {
-              if (outstring != "") {
-                outstring = outstring + ", ";
+            if (power > 0.0) {
+              if (outstr != "") {
+                outstr = outstr + ", ";
               }
-              outstring =
-                outstring + `${bat_class} ${sign}${String(power)}W`;
+              outstr = outstr + `${bat_class} ${sign}${String(power)}W`;
             }
           } catch (e) {
             console.error(`Failed to read information for ${bat_class}: ${e}`);
@@ -145,7 +142,7 @@ const PowerTracker = GObject.registerClass(
         }
       }
 
-      this._label.set_text(outstring);
+      this._label.set_text(outstr);
       return
     }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -92,60 +92,61 @@ const PowerTracker = GObject.registerClass(
     }
 
     _get_power_data() {
-      var _outstring = ''
-      for (var i in ["BAT0", "BAT1", "BATT"]) {
-        const _bat = BAT_PATH_STUMP + BAT_CLASSES[i];
-        if (GLib.file_test(_bat, GLib.FileTest.IS_DIR)) {
-          const _powernow = _bat + POWER_NOW_FILE;
-          const _currentnow = _bat + CURRENT_NOW_FILE;
-          const _voltagenow = _bat + VOLTAGE_NOW_FILE;
-          var _sign = "";
-          var _power = 0.0;
+      var outstring = ''
+      for (var bat_class of BAT_CLASSES) {
+        const bat = BAT_PATH_STUMP + bat_class;
+        console.warn(`Working on ${bat_class}`)
+        if (GLib.file_test(bat, GLib.FileTest.IS_DIR)) {
+          const powernow = bat + POWER_NOW_FILE;
+          const currentnow = bat + CURRENT_NOW_FILE;
+          const voltagenow = bat + VOLTAGE_NOW_FILE;
+          var sign = "";
+          var power = 0.0;
           try {
             let decoder = new TextDecoder();
             var status = decoder
-              .decode(GLib.file_get_contents(_bat + STATUS_FILE)[1])
+              .decode(GLib.file_get_contents(bat + STATUS_FILE)[1])
               .trim();
 
             if (status === "Charging") {
-              _sign = "+";
+              sign = "+";
             }
             if (status === "Discharging") {
-              _sign = "-";
+              sign = "-";
             }
 
-            if (GLib.file_test(_powernow, GLib.FileTest.EXISTS)) {
-              _power = (
-                parseInt(decoder.decode(GLib.file_get_contents(_powernow)[1])) /
+            if (GLib.file_test(powernow, GLib.FileTest.EXISTS)) {
+              power = (
+                parseInt(decoder.decode(GLib.file_get_contents(powernow)[1])) /
                 1000000
               ).toFixed(1);
             } else if (
-              GLib.file_test(_currentnow, GLib.FileTest.EXISTS) &&
-              GLib.file_test(_voltagenow, GLib.FileTest.EXISTS)
+              GLib.file_test(currentnow, GLib.FileTest.EXISTS) &&
+              GLib.file_test(voltagenow, GLib.FileTest.EXISTS)
             ) {
-              _power = (
-                (parseInt(decoder.decode(GLib.file_get_contents(_currentnow)[1])) *
-                  parseInt(decoder.decode(GLib.file_get_contents(_voltagenow)[1]))) /
+              power = (
+                (parseInt(decoder.decode(GLib.file_get_contents(currentnow)[1])) *
+                  parseInt(decoder.decode(GLib.file_get_contents(voltagenow)[1]))) /
                 1000000000000
               ).toFixed(1);
             } else {
               throw new Error(`Couldn't find any power information endpoints!`);
             }
 
-            if (_power > 0.1) {
-              if (_outstring != "") {
-                _outstring = _outstring + ", ";
+            if (power > 0.1) {
+              if (outstring != "") {
+                outstring = outstring + ", ";
               }
-              _outstring =
-                _outstring + `${BAT_CLASSES[i]} ${_sign}${String(_power)}W`;
+              outstring =
+                outstring + `${bat_class} ${sign}${String(power)}W`;
             }
           } catch (e) {
-            console.error(`Failed to read information for ${_bat}: ${e}`);
+            console.error(`Failed to read information for ${bat}: ${e}`);
           }
         }
       }
 
-      this._label.set_text(_outstring);
+      this._label.set_text(outstring);
       return
     }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import GObject from "gi://GObject";
 import St from "gi://St";
 import Clutter from "gi://Clutter";
 import GLib from "gi://GLib";
@@ -43,218 +42,212 @@ const BAT1_LABEL = "Ext";
 const NO_POWER_DRAW_LABEL = "";
 const NO_BATTERY_LABEL = "No battery!";
 
-const PowerTracker = GObject.registerClass(
-  class PowerTracker extends PanelMenu.Button {
-    _show_zero_power = true;
-    _init(settings) {
-      this._settings = settings;
+export default class PowerTrackerExtension extends Extension {
+  show_zero_power;
+  refreshrate;
+  time_out_id = null;
 
-      // -------------
-      // CONFIGURATION
-      // -------------
-      // Settings
-      this._settings.bind(
-        "refreshrate",
-        this,
-        "refreshrate",
-        Gio.SettingsBindFlags.DEFAULT
-      );
-
-      this._settings.connect("changed::refreshrate", (settings, key) => {
-        this._set_refresh_rate();
-      });
-
-      this._settings.bind(
-        "showzeropower",
-        this,
-        "_show_zero_power",
-        Gio.SettingsBindFlags.DEFAULT
-      );
-
-      this._settings.connect('changed::showzeropower', (settings, key) => {
-        // this._show_zero_power = this._settings.get_boolean("showzeropower");
-        this._show_zero_power = settings.get_boolean(key);
-        this._get_power_data();
-      });
-
-      // -------------
-
-      this._time_out_id = null;
-      super._init(0.0, _("PowerTracker"));
-
-      this._label = new St.Label({
+  enable() {
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.enable() called >>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+    this._indicator = new PanelMenu.Button(0.0, this.metadata.name, false);
+    this._indicator._label = new St.Label({
         text: "? W",
         y_align: Clutter.ActorAlign.CENTER,
-      });
+    });
+    this._indicator.add_child(this._indicator._label);
 
-      this.add_child(this._label);
+    Main.panel.addToStatusArea(this.uuid, this._indicator);
 
-      this._get_power_data();
-      this._set_refresh_rate();
-    }
-
-    _set_refresh_rate() {
-      if (this._time_out_id) {
-        GLib.Source.remove(this._time_out_id);
-        this._time_out_id = null;
-      }
-
-      this.refreshrate = this._settings.get_int("refreshrate");
-      this._time_out_id = GLib.timeout_add_seconds(
-        GLib.PRIORITY_DEFAULT,
-        this.refreshrate,
-        () => {
-          this._get_power_data();
-          return true;
-        }
-      );
-    }
-
-    _get_power_data() {
-      // console.log("======PowerTracker._get_power_data() called==================");
-      // See https://gjs.guide/guides/gio/file-operations.html
-      var psClassDirIter;
-      try {
-        const psClassDir = Gio.File.new_for_path(POWER_SUPPLY_CLASS_DIR);
-
-        psClassDirIter = psClassDir.enumerate_children(
-          "standard::*",
-          Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
-          null,
-        );
-      }
-      catch(e) {
-        console.error(
-          `Failed to read information from ${POWER_SUPPLY_CLASS_DIR}: ${e}`,
-        );
-        this._label.set_text("ERROR");
-        return
-      }
-
-      var batDirInfo;
-      var batCount = 0;
-      var batPowerStat = [];
-      while (batDirInfo = psClassDirIter.next_file(null)) {
-        try {
-          const batDir = POWER_SUPPLY_CLASS_DIR + batDirInfo.get_name();
-          if (GLib.file_test(batDir, GLib.FileTest.IS_DIR)) {
-            const powernow = batDir + POWER_NOW_FILE;
-            const currentnow = batDir + CURRENT_NOW_FILE;
-            const voltagenow = batDir + VOLTAGE_NOW_FILE;
-            const statusfile = batDir + STATUS_FILE;
-            const typefile = batDir + TYPE_FILE;
-              var td = new TextDecoder();
-
-              if (GLib.file_test(typefile, GLib.FileTest.EXISTS)) {
-                var pstype = td.decode(GLib.file_get_contents(typefile)[1]).trim();
-                if (pstype != "Battery") {
-                  continue;
-                }
-              }
-              else {
-                continue;
-              }
-
-              var power = 0.0;
-              if (GLib.file_test(powernow, GLib.FileTest.EXISTS)) {
-                power = (
-                  parseInt(td.decode(GLib.file_get_contents(powernow)[1])) /
-                  1000000
-                ).toFixed(DECIMAL_PLACES_POWER_VAL);
-              } else if (
-                GLib.file_test(currentnow, GLib.FileTest.EXISTS) &&
-                GLib.file_test(voltagenow, GLib.FileTest.EXISTS)
-              ) {
-                power = (
-                  (parseInt(td.decode(GLib.file_get_contents(currentnow)[1])) *
-                    parseInt(td.decode(GLib.file_get_contents(voltagenow)[1]))) /
-                  1000000000000
-                ).toFixed(DECIMAL_PLACES_POWER_VAL);
-              } else {
-                continue;
-              }
-              batCount++;
-
-              var sign = "";
-              if (GLib.file_test(statusfile, GLib.FileTest.EXISTS)) {
-                var pstype = td.decode(GLib.file_get_contents(statusfile)[1]).trim();
-                if (pstype === "Charging") {
-                  sign = "+";
-                }
-                if (pstype === "Discharging") {
-                  sign = "-";
-                }
-              }
-              batPowerStat.push({"name":batDirInfo.get_name(), "sign": sign, "power":power})
-          }
-        } catch (e) {
-          console.error(
-            `Failed to read information for ${batDirInfo.get_name()}: ${e}`,
-          );
-        }
-      }
-      // console.log(batPowerStat);
-      
-      if (batPowerStat.length == 0) {
-        this._label.set_text(NO_BATTERY_LABEL);
-      }
-      else if (batPowerStat.length == 1) {
-        // We only have one battery, we don't need a label before the wattage.
-        if (batPowerStat[0].power > 0.0 || this._show_zero_power)
-          this._label.set_text(b.sign+String(batPowerStat[0].power));
-        else
-          this._label.set_text(NO_POWER_DRAW_LABEL);
-      }
-      else {
-        // We have more than one battery, we put labels before them.
-        var outstr = NO_POWER_DRAW_LABEL;
-        for (const b of batPowerStat) {
-          // console.log(`Working on ${b.name}`)
-          if (b.power > 0.0 || this._show_zero_power) {
-            if (outstr != NO_POWER_DRAW_LABEL) {
-              outstr = outstr + ", ";
-            }
-            // For known battery classes we put better labels
-            var labelname;
-            if (b.name === "BAT0") {
-              labelname = BAT0_LABEL;
-            }
-            else if (b.name === "BAT1") {
-              labelname = BAT1_LABEL;
-            }
-            else {
-              labelname = b.name;
-            }
-            outstr = outstr + `${labelname} ${b.sign}${String(b.power)}W`;
-          }
-        }
-        this._label.set_text(outstr);
-      }
-      // console.log("======PowerTracker._get_power_data() finished================");
-    }
-
-    destroy() {
-      if (this._time_out_id) {
-        GLib.Source.remove(this._time_out_id);
-        this._time_out_id = null;
-      }
-      super.destroy();
-    }
-  }
-);
-
-export default class PowerTrackerExtension extends Extension {
-  enable() {
-    this._powertracker = new PowerTracker(this.getSettings());
-    Main.panel.addToStatusArea(this.uuid, this._powertracker);
-
-    this._powertracker.menu.addAction(_("Preferences"), () =>
+    this._indicator.menu.addAction(_("Preferences"), () =>
       this.openPreferences()
     );
+
+    this._settings = this.getSettings();
+    this.set_refreshrate(this._settings.get_int("refreshrate"));
+    this.set_show_zero_power(this._settings.get_boolean("showzeropower"));
+
+    this._settings.connect("changed::refreshrate", (settings, key) => {
+      this.set_refreshrate(this._settings.get_int(key));
+      console.log(`>>>>>>>>>>> Refreshrate changed to ${String(this.refreshrate)}`);
+    });
+
+    this._settings.connect('changed::showzeropower', (settings, key) => {
+      this.set_show_zero_power(this._settings.get_boolean(key));
+      console.log(`>>>>>>>>>>> Show Zero Power now set to ${String(this.show_zero_power)}`)
+    });
+
+    this.update_label();
+    console.log(`PowerTrackerExtension initialized with refreshrate=${this.refreshrate} and show_zero_power=${this.show_zero_power}`);
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.enable() finished >>>>>>>>>>>>>>>>>>>>>>>>>>")
   }
 
   disable() {
-    this._powertracker.destroy();
-    this._powertracker = null;
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.disable() called >>>>>>>>>>>>>>>>>>>>>>>>>>>")
+    if (this.time_out_id) {
+      GLib.Source.remove(this.time_out_id);
+      this.time_out_id = null;
+    }
+    this._indicator?.destroy();
+    this._indicator = null;
+    this._settings = null;
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.disable() finished >>>>>>>>>>>>>>>>>>>>>>>>>")
+  }
+
+  get_power_data() {
+    console.log("======PowerTracker.get_power_data() called==================");
+    // See https://gjs.guide/guides/gio/file-operations.html
+    var psClassDirIter;
+    try {
+      const psClassDir = Gio.File.new_for_path(POWER_SUPPLY_CLASS_DIR);
+
+      psClassDirIter = psClassDir.enumerate_children(
+        "standard::*",
+        Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+        null,
+      );
+    }
+    catch(e) {
+      console.error(
+        `Failed to read information from ${POWER_SUPPLY_CLASS_DIR}: ${e}`,
+      );
+      this._label.set_text("ERROR");
+      return
+    }
+
+    var batDirInfo;
+    var batCount = 0;
+    var batPowerStat = [];
+    while (batDirInfo = psClassDirIter.next_file(null)) {
+      try {
+        const batDir = POWER_SUPPLY_CLASS_DIR + batDirInfo.get_name();
+        if (GLib.file_test(batDir, GLib.FileTest.IS_DIR)) {
+          const powernow = batDir + POWER_NOW_FILE;
+          const currentnow = batDir + CURRENT_NOW_FILE;
+          const voltagenow = batDir + VOLTAGE_NOW_FILE;
+          const statusfile = batDir + STATUS_FILE;
+          const typefile = batDir + TYPE_FILE;
+            var td = new TextDecoder();
+
+            if (GLib.file_test(typefile, GLib.FileTest.EXISTS)) {
+              var pstype = td.decode(GLib.file_get_contents(typefile)[1]).trim();
+              if (pstype != "Battery") {
+                continue;
+              }
+            }
+            else {
+              continue;
+            }
+
+            var power = 0.0;
+            if (GLib.file_test(powernow, GLib.FileTest.EXISTS)) {
+              power = (
+                parseInt(td.decode(GLib.file_get_contents(powernow)[1])) /
+                1000000
+              ).toFixed(DECIMAL_PLACES_POWER_VAL);
+            } else if (
+              GLib.file_test(currentnow, GLib.FileTest.EXISTS) &&
+              GLib.file_test(voltagenow, GLib.FileTest.EXISTS)
+            ) {
+              power = (
+                (parseInt(td.decode(GLib.file_get_contents(currentnow)[1])) *
+                  parseInt(td.decode(GLib.file_get_contents(voltagenow)[1]))) /
+                1000000000000
+              ).toFixed(DECIMAL_PLACES_POWER_VAL);
+            } else {
+              continue;
+            }
+            batCount++;
+
+            var sign = "";
+            if (GLib.file_test(statusfile, GLib.FileTest.EXISTS)) {
+              var pstype = td.decode(GLib.file_get_contents(statusfile)[1]).trim();
+              if (pstype === "Charging") {
+                sign = "+";
+              }
+              if (pstype === "Discharging") {
+                sign = "-";
+              }
+            }
+            batPowerStat.push({"name":batDirInfo.get_name(), "sign": sign, "power":power})
+        }
+      } catch (e) {
+        console.error(
+          `Failed to read information for ${batDirInfo.get_name()}: ${e}`,
+        );
+      }
+    }
+    // console.log(batPowerStat);
+    console.log("======PowerTracker.get_power_data() finished================");
+    return batPowerStat;
+  }
+
+  update_label() {
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.update_label() called >>>>>>>>>>>>>>>>>>>>>>")
+    var batPowerStat = this.get_power_data();
+    if (batPowerStat.length == 0) {
+      this._indicator._label.set_text(NO_BATTERY_LABEL);
+    }
+    else if (batPowerStat.length == 1) {
+      // We only have one battery, we don't need a label before the wattage.
+      if (batPowerStat[0].power > 0.0 || this.show_zero_power)
+        this._indicator._label.set_text(b.sign+String(batPowerStat[0].power));
+      else
+        this._indicator._label.set_text(NO_POWER_DRAW_LABEL);
+    }
+    else {
+      // We have more than one battery, we put labels before them.
+      var outstr = NO_POWER_DRAW_LABEL;
+      for (const b of batPowerStat) {
+        // console.log(`Working on ${b.name}`)
+        if (b.power > 0.0 || this.show_zero_power) {
+          if (outstr != NO_POWER_DRAW_LABEL) {
+            outstr = outstr + ", ";
+          }
+          // For known battery classes we use better labels
+          var labelname;
+          if (b.name === "BAT0") {
+            labelname = BAT0_LABEL;
+          }
+          else if (b.name === "BAT1") {
+            labelname = BAT1_LABEL;
+          }
+          else {
+            labelname = b.name;
+          }
+          outstr = outstr + `${labelname} ${b.sign}${String(b.power)}W`;
+        }
+      }
+      console.log(`##### outstr=${outstr}`)
+      this._indicator._label.set_text(outstr);
+    }
+    console.log("<<<<<<<<<<<<<<<<<<<<<<<<<< PowerTrackerExtension.update_label() finished >>>>>>>>>>>>>>>>>>>>")
+  }
+
+  set_show_zero_power(show_zero_power) {
+    console.log("======PowerTracker.set_show_zero_power() called==================");
+    this.show_zero_power = show_zero_power;
+    this.update_label();
+    console.log(`New setting: show_zero_power=${this.show_zero_power}`)
+    console.log("======PowerTracker.set_show_zero_power() finished================");
+  }
+
+  set_refreshrate(refreshrate) {
+    console.log("======PowerTracker.config_refresh_rate() called==================");
+    this.refreshrate = refreshrate;
+    console.log(`New setting: refreshrate=${this.refreshrate}`)
+    if (this.time_out_id) {
+      GLib.Source.remove(this.time_out_id);
+      this.time_out_id = null;
+    }
+
+    this.time_out_id = GLib.timeout_add_seconds(
+      GLib.PRIORITY_DEFAULT,
+      refreshrate,
+      () => {
+        this.update_label();
+        return true;
+      }
+    );
+    console.log("======PowerTracker.config_refresh_rate() finished================");
   }
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -41,5 +41,14 @@ export default class PowerTrackerPreferences extends ExtensionPreferences {
       "value",
       Gio.SettingsBindFlags.DEFAULT
     );
+
+    const showZeroPower = new Adw.SwitchRow({
+    title: _('Show 0.0W power'),
+      subtitle: _('Show a 0.0W power value instead of hiding it.'),
+    });
+
+    group.add(showZeroPower);
+
+    window._settings.bind("showzeropower",showZeroPower,'active',Gio.SettingsBindFlags.DEFAULT);
   }
 }


### PR DESCRIPTION
Hi.

this is a fix for issue #19, where only the second battery is displayed. It works on my Thinkpad T480 without any issues.

It now searches for all batteries under /sys/class/power_supply regardless of their name and displays the power values. I added the option to suppress the display of 0.0W values. The reason is that in reality (at least on my laptop) only one battery is used at a time. So lot of screen estate is wasted displaying 0.0W for the unused battery.

I added a preferences setting for this. I also added the German translation. But since I don't speak neither Spanish nor Catalan I couldn't add the translation for those.

Now for the difficult part. I completely restructured the code. Everything is moved to a single class. I also removed a few unnecessary lines. There is basically no stone left unturned in the code. I understand it if you as the original author and owner of the extension do not like this and that you reject my pull request. That's fine. Just let me know.

Bernd