### PR TITLE
Add Math.abs to raw_power calculation

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -120,7 +120,7 @@ const PowerTracker = GObject.registerClass(
       } else {
         var current = this._get_file_value(CURRENT_NOW_FILE);
         var voltage = this._get_file_value(VOLTAGE_NOW_FILE);
-        raw_power = (current * voltage) / 1000000000000;
+        raw_power = Math.abs(current * voltage) / 1000000000000;
       }
 
       var power = raw_power.toLocaleString(undefined, {


### PR DESCRIPTION
This fixes the double negative sign while on battery power.

![image](https://github.com/user-attachments/assets/150d7c8a-caf5-42f5-8199-e77ef4cc964a)