### PR TITLE
Added Gnome 50 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,6 +3,7 @@
   "description": "Tracks current power consumption",
   "uuid": "marcs14@gmail.com",
   "shell-version": [
+    "50",
     "49",
     "48",
     "47",


### PR DESCRIPTION
Closes https://github.com/Pijuli/GnomePowerTracker/issues/29

Tested locally on a Thinkpad L14 G1 and it works, running openSUSE Tumbleweed on Gnome 50